### PR TITLE
fix(image-builder): use the proper tmp path

### DIFF
--- a/src/fs-gen/src/image_builder.rs
+++ b/src/fs-gen/src/image_builder.rs
@@ -44,7 +44,7 @@ fn new_passthroughfs_layer(rootdir: &str) -> Result<BoxedLayer> {
 
 /// Ensure a destination folder is created
 fn ensure_folder_created(output_folder: &Path) -> Result<()> {
-    let result = fs::create_dir(output_folder);
+    let result = fs::create_dir_all(output_folder);
 
     // If the file already exists, we're fine
     if result.is_err() {

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -30,7 +30,8 @@ fn main() {
             // FIXME: use a subdir of the temp directory instead
             let path = Path::new(overlay_subdir.as_path());
 
-            merge_layer(&layers_paths, path).expect("Merging layers failed");
+            merge_layer(&layers_paths, path, &args.temp_directory.clone())
+                .expect("Merging layers failed");
             create_init_file(path);
             generate_initramfs(path, Path::new(args.output_file.as_path()));
         }

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -13,6 +13,7 @@ fn main() {
     println!("Hello, world!, {:?}", args);
 
     let layers_subdir = args.temp_directory.clone().join("layers/");
+    let output_subdir = args.temp_directory.clone().join("output/");
     let overlay_subdir = args.temp_directory.clone().join("overlay/");
 
     // TODO: better organise layers and OverlayFS build in the temp directory
@@ -28,10 +29,9 @@ fn main() {
             }
 
             // FIXME: use a subdir of the temp directory instead
-            let path = Path::new(overlay_subdir.as_path());
+            let path = Path::new(output_subdir.as_path());
 
-            merge_layer(&layers_paths, path, &args.temp_directory.clone())
-                .expect("Merging layers failed");
+            merge_layer(&layers_paths, path, &overlay_subdir).expect("Merging layers failed");
             create_init_file(path);
             generate_initramfs(path, Path::new(args.output_file.as_path()));
         }


### PR DESCRIPTION
# Hi there 

This PR brings a new argument to the image builder function. It is now aware of the temp folder to use instead of relying on `/tmp` all the time.