### PR TITLE
feat(arg-parsing): make the tag optional

### DIFF
--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -7,7 +7,7 @@ use once_cell::sync::Lazy;
 
 // So, for any of you who may be scared, this is the regex from the OCI Distribution Sepcification for the image name + the tag
 static RE_IMAGE_NAME: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*:[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}").unwrap()
+    Regex::new(r"[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*(?::[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127})?").unwrap()
 });
 
 /// Convert an OCI image into a CPIO file


### PR DESCRIPTION
# Hello there

As per @sea-gull-diana request, the tag is now optional for the CLI. Allowing to use `cargo run ubuntu ./test`