### PR TITLE
Feat/manifest download and deserialization

### DIFF
--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -14,7 +14,7 @@ static RE_IMAGE_NAME: Lazy<Regex> = Lazy::new(|| {
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
 pub struct CliArgs {
-    /// The name of the image to download
+    /// The name of the image to download, can include repository and tag: [REPOSITORY/NAME:TAG]
     pub image_name: String,
 
     /// The host path to the guest agent binary

--- a/src/fs-gen/src/loader/errors.rs
+++ b/src/fs-gen/src/loader/errors.rs
@@ -1,19 +1,20 @@
+use crate::loader::structs::Image;
 use anyhow::Error;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub(crate) enum ImageLoaderError {
     /// There is no existing manifest for the given image.
-    #[error("Could not find Docker v2 or OCI manifest for `{0}:{1}`")]
-    ManifestNotFound(String, String),
+    #[error("Could not find Docker v2 or OCI manifest for `{0}`")]
+    ManifestNotFound(Image),
 
     /// Image doesn't support the requested architecture.
     #[error("This image doesn't support {0} architecture")]
     UnsupportedArchitecture(String),
 
-    /// The manifest doesn't contain any layers to unpack.
-    #[error("Could not find image layers in the manifest")]
-    LayersNotFound,
+    /// The image manifest doesn't match the expected structure (no "layers" property).
+    #[error("Could not find Docker v2 or OCI image manifest for `{0}`")]
+    ImageManifestNotFound(Image),
 
     /// Encountered an error during the flow.
     #[error("Image loading error: {}", .source)]

--- a/src/fs-gen/src/loader/mod.rs
+++ b/src/fs-gen/src/loader/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod download;
 pub(crate) mod errors;
+mod structs;
 mod utils;

--- a/src/fs-gen/src/loader/structs.rs
+++ b/src/fs-gen/src/loader/structs.rs
@@ -1,0 +1,58 @@
+use serde::Deserialize;
+use serde_json::Value;
+use std::fmt;
+
+// Any json returned by the request: image manifest, fat manifest, error...
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum ManifestV2 {
+    ImageManifest(ImageManifest),
+    ManifestList(ManifestList),
+    Other(Value),
+}
+
+// Docker v2 or OCI mage manifest containing image layers
+#[derive(Debug, Deserialize)]
+pub struct ImageManifest {
+    pub layers: Vec<Layer>,
+}
+
+// Image layer
+#[derive(Debug, Deserialize)]
+pub struct Layer {
+    pub digest: String,
+}
+
+// Docker v2 manifest list or OCI image index containing image manifests
+#[derive(Debug, Deserialize)]
+pub struct ManifestList {
+    pub manifests: Vec<SubManifest>,
+}
+
+// SubManifest for a specific platform
+#[derive(Debug, Deserialize)]
+pub struct SubManifest {
+    pub digest: String,
+    pub platform: Platform,
+}
+
+// Supported image platform: architecture and OS
+#[derive(Debug, Deserialize)]
+pub struct Platform {
+    pub architecture: String,
+    pub os: String,
+}
+
+// Container image definition consisting of repository, name and tag
+#[derive(Debug, Clone)]
+pub struct Image {
+    pub repository: String,
+    pub name: String,
+    pub tag: String,
+}
+
+impl fmt::Display for Image {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}/{}:{}", self.repository, self.name, self.tag)
+    }
+}

--- a/src/fs-gen/src/loader/utils.rs
+++ b/src/fs-gen/src/loader/utils.rs
@@ -1,3 +1,4 @@
+use crate::loader::structs::Image;
 use anyhow::{Context, Result};
 use flate2::read::GzDecoder;
 use reqwest::blocking::{Client, Response};
@@ -13,17 +14,46 @@ pub(super) fn unpack_tarball(response: Response, output_dir: &Path) -> Result<()
 }
 
 /// Get a token for anonymous authentication to Docker Hub.
-pub(super) fn get_docker_download_token(client: &Client, image_name: &str) -> Result<String> {
+pub(super) fn get_docker_download_token(client: &Client, image: &Image) -> Result<String> {
     let token_json: serde_json::Value = client
-        .get(format!("https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/{image_name}:pull"))
-        .send().with_context(|| "Could not send request for anonymous authentication".to_string())?
-        .json().with_context(|| "Failed to parse JSON response for anonymous authentication".to_string())?;
+        .get(format!(
+            "https://auth.docker.io/token?service=registry.docker.io&scope=repository:{}/{}:pull",
+            image.repository, image.name
+        ))
+        .send()
+        .with_context(|| "Could not send request for anonymous authentication".to_string())?
+        .json()
+        .with_context(|| {
+            "Failed to parse JSON response for anonymous authentication".to_string()
+        })?;
 
     match token_json["token"]
         .as_str()
-        .with_context(|| "Failed to get token from anon auth response".to_string())
+        .with_context(|| "Failed to get token from the anonymous auth response".to_string())
     {
         Ok(t) => Ok(t.to_owned()),
         Err(e) => Err(e),
+    }
+}
+
+// Get image's repository, name and tag
+pub(super) fn split_image_name(image_name: &str) -> Image {
+    let repo_and_image: Vec<&str> = image_name.split('/').collect();
+
+    let (repository, name) = if repo_and_image.len() < 2 {
+        ("library".to_string(), repo_and_image[0].to_string())
+    } else {
+        (repo_and_image[0].to_string(), repo_and_image[1].to_string())
+    };
+    let image_and_tag: Vec<&str> = name.split(':').collect();
+    let (name, tag) = if image_and_tag.len() < 2 {
+        (image_and_tag[0].to_string(), "latest".to_string())
+    } else {
+        (image_and_tag[0].to_string(), image_and_tag[1].to_string())
+    };
+    Image {
+        repository,
+        name,
+        tag,
     }
 }

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -62,10 +62,6 @@ fn main() -> Result<()> {
         )
         .init();
 
-    // tracing_subscriber::fmt()
-    //     .with_max_level(if args.debug { Level::DEBUG } else { Level::INFO })
-    //     .init();
-
     info!(
         "Cloudlet initramfs generator: '{}' v{}",
         env!("CARGO_PKG_NAME"),


### PR DESCRIPTION
### This PR does two things:
1. Manifest deserialization is improved, as promised, by adding structs to describe the structure of the two manifest types: image manifest and manifest list. No more unwraps in the loader section :tada: 
2. We are now supporting other Docker Hub public repositories than "library" as well, i.e. it is possible to provide the image in any of the following ways:
- REPOSITORY/NAME:TAG
- REPOSITORY/NAME
- NAME:TAG
- NAME
The default repository and tag remain "library" and "latest" respectively.

I have also modified a few error names and messages. And executed `cargo fmt`, sorry if it causes conflicts later.