### PR TITLE
Feat/registry auth

### DIFF
--- a/src/fs-gen/Cargo.toml
+++ b/src/fs-gen/Cargo.toml
@@ -22,3 +22,4 @@ anyhow = "1.0.82"
 tracing = "0.1.40"
 tracing-subscriber = {  version = "0.3.18", features = ["env-filter"] }
 thiserror = "1.0.59"
+clap-stdin = "0.4.0"

--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -1,6 +1,7 @@
 use std::{env, path::PathBuf};
 
 use clap::{command, error::ErrorKind, ArgAction, CommandFactory, Parser};
+use clap_stdin::MaybeStdin;
 use regex::Regex;
 
 use once_cell::sync::Lazy;
@@ -38,12 +39,12 @@ pub struct CliArgs {
     pub debug: bool,
 
     /// Username to pull image from a private repository
-    #[arg(short='u', default_value=None)]
+    #[arg(short='u', long="username", default_value=None)]
     pub username: Option<String>,
 
-    /// Password to pull image from a private repository
-    #[arg(short='p', default_value=None)]
-    pub password: Option<String>,
+    /// Password can also be passed via STDIN: [echo <PASSWORD> | fs-gen ... -p -]
+    #[arg(short='p', long="password", default_value=None)]
+    pub password: Option<MaybeStdin<String>>,
 }
 
 impl CliArgs {

--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -45,6 +45,10 @@ pub struct CliArgs {
     /// Password can also be passed via STDIN: [echo <PASSWORD> | fs-gen ... -p -]
     #[arg(short='p', long="password", default_value=None)]
     pub password: Option<MaybeStdin<String>>,
+
+    /// Allow invalid TLS certificates
+    #[arg(long="insecure", action=ArgAction::SetTrue)]
+    pub insecure: bool,
 }
 
 impl CliArgs {

--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -36,6 +36,14 @@ pub struct CliArgs {
 
     #[arg(short='d', long="debug", action=ArgAction::SetTrue)]
     pub debug: bool,
+
+    /// Username to pull image from a private repository
+    #[arg(short='u', default_value=None)]
+    pub username: Option<String>,
+
+    /// Password to pull image from a private repository
+    #[arg(short='p', default_value=None)]
+    pub password: Option<String>,
 }
 
 impl CliArgs {
@@ -45,6 +53,7 @@ impl CliArgs {
 
         args.validate_image();
         args.validate_host_path();
+        args.validate_auth();
 
         args
     }
@@ -69,6 +78,26 @@ impl CliArgs {
                     "File not found for agent binary: \"{}\"",
                     self.agent_host_path.to_string_lossy()
                 ),
+            )
+            .exit();
+        }
+    }
+
+    fn validate_auth(&self) {
+        let mut cmd = CliArgs::command();
+        let instruction =
+            "Define both username and password to connect to a private image repository.";
+        if self.username.is_none() && self.password.is_some() {
+            cmd.error(
+                ErrorKind::InvalidValue,
+                format!("Username not provided. {}", instruction),
+            )
+            .exit();
+        }
+        if self.username.is_some() && self.password.is_none() {
+            cmd.error(
+                ErrorKind::InvalidValue,
+                format!("Password not provided. {}", instruction),
             )
             .exit();
         }

--- a/src/fs-gen/src/loader/download.rs
+++ b/src/fs-gen/src/loader/download.rs
@@ -2,6 +2,7 @@ use crate::loader::errors::ImageLoaderError;
 use crate::loader::structs::{Layer, ManifestV2};
 use crate::loader::utils::{get_docker_download_token, unpack_tarball};
 use anyhow::{Context, Result};
+use clap_stdin::MaybeStdin;
 use reqwest::blocking::Client;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
@@ -14,7 +15,7 @@ pub(crate) fn download_image_fs(
     architecture: &str,
     output_file: PathBuf,
     username: Option<String>,
-    password: Option<String>,
+    password: Option<MaybeStdin<String>>,
 ) -> Result<Vec<PathBuf>, ImageLoaderError> {
     info!("Downloading image...");
     let image = Image::from_str(image_name);

--- a/src/fs-gen/src/loader/download.rs
+++ b/src/fs-gen/src/loader/download.rs
@@ -13,6 +13,8 @@ pub(crate) fn download_image_fs(
     image_name: &str,
     architecture: &str,
     output_file: PathBuf,
+    username: Option<String>,
+    password: Option<String>,
 ) -> Result<Vec<PathBuf>, ImageLoaderError> {
     info!("Downloading image...");
     let image = Image::from_str(image_name);
@@ -26,7 +28,7 @@ pub(crate) fn download_image_fs(
 
     // Get download token and download manifest
     let client = Client::new();
-    let token = &get_docker_download_token(&client, &image)?;
+    let token = &get_docker_download_token(&client, &image, username, password)?;
     let manifest = download_manifest(&client, token, &image, &image.tag)
         .map_err(|e| ImageLoaderError::Error { source: e })?;
 

--- a/src/fs-gen/src/loader/structs.rs
+++ b/src/fs-gen/src/loader/structs.rs
@@ -55,21 +55,31 @@ pub struct Image {
 impl Image {
     // Get image's repository, name and tag
     pub fn from_str(image_name: &str) -> Image {
-        const DEFAULT_REGISTRY: &str = "registry-1.docker.io";
+        const DEFAULT_REGISTRY: &str = "https://registry-1.docker.io";
         const DEFAULT_REPOSITORY: &str = "library";
         const DEFAULT_TAG: &str = "latest";
 
+        let protocol = if image_name.starts_with("http://") {
+            "http://"
+        } else {
+            "https://"
+        };
+
         let mut image_data: Vec<&str> = image_name
+            .trim_start_matches("http://")
+            .trim_start_matches("https://")
             .trim_start_matches("docker.io/")
             .splitn(3, '/')
             .collect();
 
+        // Get registry link (part of name before the first '/' with dots) or use the default registry
         let registry = if image_data[0].contains('.') {
-            image_data.remove(0).to_string()
+            format!("{}{}", protocol, image_data.remove(0))
         } else {
             DEFAULT_REGISTRY.to_string()
         };
 
+        // Set image repository and name
         let (repository, name) = match image_data.len() {
             1 => (DEFAULT_REPOSITORY.to_string(), image_data[0].to_string()),
             2 => (image_data[0].to_string(), image_data[1].to_string()),
@@ -78,6 +88,8 @@ impl Image {
                 image_data[1].to_string() + "/" + image_data[2],
             ),
         };
+
+        // Set image tag, default: 'latest'
         let image_and_tag: Vec<&str> = name.split(':').collect();
         let (name, tag) = if image_and_tag.len() < 2 {
             (image_and_tag[0].to_string(), DEFAULT_TAG.to_string())

--- a/src/fs-gen/src/loader/utils.rs
+++ b/src/fs-gen/src/loader/utils.rs
@@ -21,15 +21,16 @@ pub(super) fn get_registry_auth_data(
     image: &Image,
 ) -> Result<Registry, ImageLoaderError> {
     let manifest_url = format!(
-        "https://{}/v2/{}/{}/manifests/{}",
+        "{}/v2/{}/{}/manifests/{}",
         image.registry, image.repository, image.name, image.tag
     );
 
-    let unauth_request = client
+    let unauth_response = client
         .get(manifest_url)
         .send()
         .with_context(|| format!("Could not send request to {}", image.registry))?;
-    let auth_header: &str = unauth_request.headers()["www-authenticate"]
+
+    let auth_header: &str = unauth_response.headers()["www-authenticate"]
         .to_str()
         .map_err(|e| ImageLoaderError::Error { source: e.into() })?;
     let auth_data: Vec<&str> = auth_header.split('"').collect();

--- a/src/fs-gen/src/loader/utils.rs
+++ b/src/fs-gen/src/loader/utils.rs
@@ -1,6 +1,7 @@
 use crate::loader::errors::ImageLoaderError;
 use crate::loader::structs::{Image, Registry};
 use anyhow::{Context, Result};
+use clap_stdin::MaybeStdin;
 use flate2::read::GzDecoder;
 use reqwest::blocking::{Client, Response};
 use std::path::Path;
@@ -49,7 +50,7 @@ pub(super) fn get_docker_download_token(
     client: &Client,
     image: &Image,
     username: Option<String>,
-    password: Option<String>,
+    password: Option<MaybeStdin<String>>,
 ) -> Result<String> {
     let registry = get_registry_auth_data(client, image)?;
 

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -21,8 +21,13 @@ fn run(args: CliArgs) -> Result<()> {
     let output_subdir = _binding.as_path();
 
     // image downloading and unpacking
-    let layers_paths = match download_image_fs(&args.image_name, &args.architecture, layers_subdir)
-    {
+    let layers_paths = match download_image_fs(
+        &args.image_name,
+        &args.architecture,
+        layers_subdir,
+        args.username,
+        args.password,
+    ) {
         Err(e) => bail!(e),
         Ok(e) => e,
     };

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -27,6 +27,7 @@ fn run(args: CliArgs) -> Result<()> {
         layers_subdir,
         args.username,
         args.password,
+        args.insecure,
     ) {
         Err(e) => bail!(e),
         Ok(e) => e,


### PR DESCRIPTION
### This PR does the following:
- Allows authenticating to a private image repository by passing your username and password as CLI arguments:
  - `-u <USERNAME>`
  - `-p <PASSWORD>`
- Allows passing password via STDIN: `echo "<PASSWORD>" | fs-gen ... -p -`
- Makes possible to connect to a container registry with an invalid TLS certificate using the `--insecure` CLI argument.
- Adds additional possible format to image name: `(https:// or http://)REGISTRY/...`. For example: both `ghcr.io/linuxcontainers/alpine:3.18.0` and `https://ghcr.io/linuxcontainers/alpine:3.18.0` would work.